### PR TITLE
Floating = true

### DIFF
--- a/content/blocks/power/magmatic-generator.json
+++ b/content/blocks/power/magmatic-generator.json
@@ -9,6 +9,7 @@
     "buildCostMultiplier": 0.6,
     "powerProduction": 3,
     "attribute": "heat",
+    "floating": true,
     "generateEffect": "melting",
     "requirements": [
         {


### PR DESCRIPTION
In the code for thermal generator, you'll find floating = true: 
![floating = true](https://user-images.githubusercontent.com/68400583/110573522-427ed400-8110-11eb-836b-1249fca697dc.jpg)

This allows the thermal generators to be placed on slag, which is why I was surprised when the Magmatic Generator could not be.

This PR allows the Magmatic Generator to be placed on slag. 
